### PR TITLE
Bump runtime version to fix @variable errors

### DIFF
--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "ISC",
       "dependencies": {
-        "@observablehq/runtime": "^4.21.1"
+        "@observablehq/runtime": "^4.25.0"
       },
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^7.1.1",
@@ -29,9 +29,9 @@
       }
     },
     "node_modules/@observablehq/runtime": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/@observablehq/runtime/-/runtime-4.21.1.tgz",
-      "integrity": "sha512-bCJ++R7bFpBBwEZKlSHiw6+OJFfFqDOal0anoZAydg8JwD3GnujQCmIsvUl//NvliAkncMeMACmCUM8sdup+yg==",
+      "version": "4.25.0",
+      "resolved": "https://registry.npmjs.org/@observablehq/runtime/-/runtime-4.25.0.tgz",
+      "integrity": "sha512-QnJOhbsal4jkTj33xI1kv+k5XXHODVsrR6bTGgqAe2C3Zd2DCRlm6MVezaGf565aPdY52bnaNt9L6t3ZQbf4yQ==",
       "dependencies": {
         "@observablehq/inspector": "^3.2.2",
         "@observablehq/stdlib": "^3.4.1"
@@ -1581,9 +1581,9 @@
       }
     },
     "@observablehq/runtime": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/@observablehq/runtime/-/runtime-4.21.1.tgz",
-      "integrity": "sha512-bCJ++R7bFpBBwEZKlSHiw6+OJFfFqDOal0anoZAydg8JwD3GnujQCmIsvUl//NvliAkncMeMACmCUM8sdup+yg==",
+      "version": "4.25.0",
+      "resolved": "https://registry.npmjs.org/@observablehq/runtime/-/runtime-4.25.0.tgz",
+      "integrity": "sha512-QnJOhbsal4jkTj33xI1kv+k5XXHODVsrR6bTGgqAe2C3Zd2DCRlm6MVezaGf565aPdY52bnaNt9L6t3ZQbf4yQ==",
       "requires": {
         "@observablehq/inspector": "^3.2.2",
         "@observablehq/stdlib": "^3.4.1"

--- a/js/package.json
+++ b/js/package.json
@@ -8,7 +8,7 @@
   "license": "ISC",
   "private": true,
   "dependencies": {
-    "@observablehq/runtime": "^4.21.1"
+    "@observablehq/runtime": "^4.25.0"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^7.1.1",


### PR DESCRIPTION
See https://talk.observablehq.com/t/error-with-observable-jupyter-embeds/7052. Notebooks that're dynamically loaded are now using an incompatibly compiled module unless you upgrade the runtime to v4.25.0; see https://github.com/observablehq/runtime/issues/342. Haven't tested this at all, just cloned to run npm. Hi Tom!﻿
