### PR TITLE
Update jupyter_embed.py

### DIFF
--- a/observable_jupyter/jupyter_embed.py
+++ b/observable_jupyter/jupyter_embed.py
@@ -11,7 +11,7 @@ from typing import List, Dict
 iframe_bundle_fname = pkg_resources.resource_filename(
     "observable_jupyter", "iframe_bundle.js"
 )
-iframe_bundle_src = open(iframe_bundle_fname).read()
+iframe_bundle_src = open(iframe_bundle_fname, encoding = 'utf-8').read()
 wrapper_bundle_fname = pkg_resources.resource_filename(
     "observable_jupyter", "wrapper_bundle.js"
 )


### PR DESCRIPTION
On Windows, I needed to change the encoding to 'utf-8', since that isn't the default on Windows (and is the default of Linux and mac).

After the simple update I was able to use the embed function in my notebooks.